### PR TITLE
Feat: 상품 논리적 삭제

### DIFF
--- a/src/main/kotlin/com/naever/store/common/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/naever/store/common/BaseTimeEntity.kt
@@ -4,9 +4,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
 import org.hibernate.annotations.CreationTimestamp
-import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
-import java.time.LocalDateTime
 import java.time.ZonedDateTime
 
 
@@ -17,4 +15,7 @@ abstract class BaseTimeEntity {
     @CreationTimestamp // Spring Data JPA에서 제공하는 Auditing 어노테이션. 각 엔티티의 생성일자를 추적함.
     @Column(nullable = false)
     var createdAt: ZonedDateTime = ZonedDateTime.now()
+
+    @Column(name = "is_deleted")
+    var isDeleted: Boolean = false
 }

--- a/src/main/kotlin/com/naever/store/domain/product/model/Product.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/model/Product.kt
@@ -4,9 +4,11 @@ import com.naever.store.common.BaseTimeEntity
 import com.naever.store.domain.product.dto.ProductRequest
 import com.naever.store.domain.user.model.User
 import jakarta.persistence.*
+import org.hibernate.annotations.SQLRestriction
 
 @Entity
 @Table(name = "product")
+@SQLRestriction("is_deleted <> true")
 class Product(
 
     @Column(name = "item_name")
@@ -51,6 +53,10 @@ class Product(
         price = request.price
         description = request.description
         quantity = request.quantity
+    }
+
+    fun deleteProduct() {
+        isDeleted = true
     }
 
 }

--- a/src/main/kotlin/com/naever/store/domain/product/service/ProductServiceImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/service/ProductServiceImpl.kt
@@ -58,7 +58,9 @@ class ProductServiceImpl(
 
         val product = getProductIfAuthorized(userId, productId)
 
-        productRepository.deleteProductById(product.id!!)
+        product.deleteProduct()
+
+        productRepository.save(product)
     }
 
     private fun getProductIfAuthorized(userId: Long, productId: Long): Product {


### PR DESCRIPTION
## 연관된 이슈

close #18 
상품 논리적 삭제

## 작업 내용

- BaseTimeEntity 에 is_deleted 컬럼 추가
- 상품 삭제 시 is_deleted 컬럼을 true 로 수정
- Product Entity에서 is_deleted 컬럼이 true 가 아닌 경우만 조회하도록 제한