### PR TITLE
[FEAT] 상점

### DIFF
--- a/src/main/kotlin/com/naever/store/common/RepositoryConfig.kt
+++ b/src/main/kotlin/com/naever/store/common/RepositoryConfig.kt
@@ -3,6 +3,9 @@ package com.naever.store.common
 import com.naever.store.domain.product.repository.IProductRepository
 import com.naever.store.domain.product.repository.ProductJpaRepository
 import com.naever.store.domain.product.repository.ProductRepositoryImpl
+import com.naever.store.domain.store.repository.IStoreRepository
+import com.naever.store.domain.store.repository.StoreJpaRepository
+import com.naever.store.domain.store.repository.StoreRepositoryImpl
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -12,5 +15,10 @@ class RepositoryConfig {
     @Bean
     fun productRepository(productJpaRepository: ProductJpaRepository): IProductRepository {
         return ProductRepositoryImpl(productJpaRepository)
+    }
+
+    @Bean
+    fun storeRepository(storeJpaRepository: StoreJpaRepository): IStoreRepository {
+        return StoreRepositoryImpl(storeJpaRepository)
     }
 }

--- a/src/main/kotlin/com/naever/store/domain/product/controller/ProductController.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/controller/ProductController.kt
@@ -2,19 +2,12 @@ package com.naever.store.domain.product.controller
 
 import com.naever.store.domain.product.dto.ProductPageRequest
 import com.naever.store.domain.product.dto.ProductPageResponse
-import com.naever.store.domain.product.dto.ProductRequest
 import com.naever.store.domain.product.dto.ProductResponse
 import com.naever.store.domain.product.service.ProductService
-import com.naever.store.infra.security.UserPrincipal
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -25,19 +18,8 @@ class ProductController(
     private val productService: ProductService
 ) {
 
-    @PostMapping
-    fun registerProduct(
-        @AuthenticationPrincipal userPrincipal: UserPrincipal,
-        @RequestBody request: ProductRequest
-    ): ResponseEntity<ProductResponse> {
-
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(productService.registerProduct(userPrincipal.id, request))
-    }
-
     @GetMapping
-    fun getProductList(
+    fun getAllProductList(
         @RequestParam(defaultValue = "1") pageNumber: Int,
         @RequestParam(defaultValue = "5") pageSize: Int,
         request: ProductPageRequest
@@ -54,31 +36,6 @@ class ProductController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(productService.getProductById(productId))
-    }
-
-    @PutMapping("/{productId}")
-    fun updateProduct(
-        @AuthenticationPrincipal userPrincipal: UserPrincipal,
-        @PathVariable productId: Long,
-        @RequestBody request: ProductRequest
-    ): ResponseEntity<ProductResponse> {
-
-        return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(productService.updateProduct(userPrincipal.id, productId, request))
-    }
-
-    @DeleteMapping("/{productId}")
-    fun deleteProduct(
-        @AuthenticationPrincipal userPrincipal: UserPrincipal,
-        @PathVariable productId: Long
-    ): ResponseEntity<Unit> {
-
-        productService.deleteProduct(userPrincipal.id, productId)
-
-        return ResponseEntity
-            .status(HttpStatus.NO_CONTENT)
-            .build()
     }
 
 }

--- a/src/main/kotlin/com/naever/store/domain/product/dto/ProductPageRequest.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/dto/ProductPageRequest.kt
@@ -4,5 +4,6 @@ data class ProductPageRequest(
     val sort: String?,
     val itemName: String?,
     val startPrice: Int?,
-    val endPrice: Int?
+    val endPrice: Int?,
+    val storeId: Long?
 )

--- a/src/main/kotlin/com/naever/store/domain/product/dto/ProductResponse.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/dto/ProductResponse.kt
@@ -10,7 +10,7 @@ data class ProductResponse(
     val quantity: Int,
     val sales: Int,
     val availability: Boolean,
-    val userId: Long?,
+    val storeName: String,
 ) {
     companion object {
         fun from(product: Product) : ProductResponse {
@@ -22,7 +22,7 @@ data class ProductResponse(
                 quantity = product.quantity,
                 sales = product.sales,
                 availability = product.availability,
-                userId = product.user.id
+                storeName = product.store.name
             )
         }
     }

--- a/src/main/kotlin/com/naever/store/domain/product/model/Product.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/model/Product.kt
@@ -2,7 +2,7 @@ package com.naever.store.domain.product.model
 
 import com.naever.store.common.BaseTimeEntity
 import com.naever.store.domain.product.dto.ProductRequest
-import com.naever.store.domain.user.model.User
+import com.naever.store.domain.store.model.Store
 import jakarta.persistence.*
 
 @Entity
@@ -28,8 +28,8 @@ class Product(
     var description: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    val user: User
+    @JoinColumn(name = "store_id")
+    val store: Store
 
 ) : BaseTimeEntity() {
     init {
@@ -42,8 +42,8 @@ class Product(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
 
-    fun matchUserId(requestUserId: Long): Boolean {
-        return user.id == requestUserId
+    fun matchStoreId(requestStoreId: Long): Boolean {
+        return store.id == requestStoreId
     }
 
     fun updateProduct(request: ProductRequest) {

--- a/src/main/kotlin/com/naever/store/domain/product/repository/IProductRepository.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/repository/IProductRepository.kt
@@ -14,4 +14,6 @@ interface IProductRepository {
 
     fun deleteProductById(id: Long)
 
+    fun deleteAllByStoreId(storeId: Long)
+
 }

--- a/src/main/kotlin/com/naever/store/domain/product/repository/ProductRepositoryImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/repository/ProductRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.naever.store.domain.product.dto.ProductResponse
 import com.naever.store.domain.product.model.Product
 import com.naever.store.domain.product.model.QProduct
 import com.naever.store.domain.store.model.QStore
+import com.naever.store.domain.user.model.QUser.user
 import com.naever.store.infra.querydsl.QueryDslSupport
 import com.querydsl.core.BooleanBuilder
 import org.springframework.data.repository.findByIdOrNull
@@ -39,6 +40,7 @@ class ProductRepositoryImpl(
         val query = queryFactory.select(product)
             .from(product)
             .leftJoin(product.store, store).fetchJoin()
+            .leftJoin(product.store.user, user).fetchJoin()
             .where(whereClause)
 
         val totalPages = ceil(query.fetch().size / pageSize.toDouble()).toInt()
@@ -73,6 +75,13 @@ class ProductRepositoryImpl(
 
     override fun deleteProductById(id: Long) {
         productJpaRepository.deleteById(id)
+    }
+
+    override fun deleteAllByStoreId(storeId: Long) {
+        queryFactory.update(product)
+            .set(product.isDeleted, true)
+            .where(product.store.id.eq(storeId))
+            .execute()
     }
 
 }

--- a/src/main/kotlin/com/naever/store/domain/product/repository/ProductRepositoryImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/repository/ProductRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.naever.store.domain.product.dto.ProductPageResponse
 import com.naever.store.domain.product.dto.ProductResponse
 import com.naever.store.domain.product.model.Product
 import com.naever.store.domain.product.model.QProduct
-import com.naever.store.domain.user.model.QUser
+import com.naever.store.domain.store.model.QStore
 import com.naever.store.infra.querydsl.QueryDslSupport
 import com.querydsl.core.BooleanBuilder
 import org.springframework.data.repository.findByIdOrNull
@@ -16,7 +16,7 @@ class ProductRepositoryImpl(
 ) : IProductRepository, QueryDslSupport() {
 
     private val product = QProduct.product
-    private val user = QUser.user
+    private val store = QStore.store
 
     override fun save(product: Product): Product {
         return productJpaRepository.save(product)
@@ -28,16 +28,17 @@ class ProductRepositoryImpl(
         request: ProductPageRequest
     ): ProductPageResponse {
 
-        val (sort, itemName, startPrice, endPrice) = request
+        val (sort, itemName, startPrice, endPrice, storeId) = request
 
         val whereClause = BooleanBuilder()
-        itemName?.let { whereClause.and(product.itemName.contains(itemName)) }
-        startPrice?.let { whereClause.and(product.price.goe(startPrice)) }
-        endPrice?.let { whereClause.and(product.price.loe(endPrice)) }
+        itemName?.let { whereClause.and(product.itemName.contains(it)) }
+        startPrice?.let { whereClause.and(product.price.goe(it)) }
+        endPrice?.let { whereClause.and(product.price.loe(it)) }
+        storeId?.let { whereClause.and(product.store.id.eq(it)) }
 
         val query = queryFactory.select(product)
             .from(product)
-            .leftJoin(product.user, user).fetchJoin()
+            .leftJoin(product.store, store).fetchJoin()
             .where(whereClause)
 
         val totalPages = ceil(query.fetch().size / pageSize.toDouble()).toInt()

--- a/src/main/kotlin/com/naever/store/domain/product/service/ProductService.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/service/ProductService.kt
@@ -7,14 +7,14 @@ import com.naever.store.domain.product.dto.ProductResponse
 
 interface ProductService {
 
-    fun registerProduct(userId: Long, request: ProductRequest): ProductResponse
-
     fun getProductList(pageNumber: Int, pageSize: Int, request: ProductPageRequest): ProductPageResponse
 
     fun getProductById(productId: Long): ProductResponse
 
-    fun updateProduct(userId: Long, productId: Long, request: ProductRequest): ProductResponse
+    fun registerProduct(storeId: Long, request: ProductRequest): ProductResponse
 
-    fun deleteProduct(userId: Long, productId: Long)
+    fun updateProduct(storeId: Long, productId: Long, request: ProductRequest): ProductResponse
+
+    fun deleteProduct(storeId: Long, productId: Long)
 
 }

--- a/src/main/kotlin/com/naever/store/domain/product/service/ProductServiceImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/product/service/ProductServiceImpl.kt
@@ -8,29 +8,15 @@ import com.naever.store.domain.product.dto.ProductRequest
 import com.naever.store.domain.product.dto.ProductResponse
 import com.naever.store.domain.product.model.Product
 import com.naever.store.domain.product.repository.IProductRepository
-import com.naever.store.domain.user.repository.UserRepository
-import org.springframework.data.repository.findByIdOrNull
+import com.naever.store.domain.store.service.StoreService
+import com.naever.store.infra.security.SecurityUtil
 import org.springframework.stereotype.Service
 
 @Service
 class ProductServiceImpl(
-    private val productRepository: IProductRepository, private val userRepository: UserRepository
+    private val productRepository: IProductRepository,
+    private val storeService: StoreService
 ) : ProductService {
-
-    override fun registerProduct(userId: Long, request: ProductRequest): ProductResponse {
-
-        val user = userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User", userId)
-
-        return Product(
-            itemName = request.itemName,
-            price = request.price,
-            quantity = request.quantity,
-            description = request.description,
-            user = user
-        ).let {
-            productRepository.save(it)
-        }.let { ProductResponse.from(it) }
-    }
 
     override fun getProductList(pageNumber: Int, pageSize: Int, request: ProductPageRequest): ProductPageResponse {
 
@@ -44,9 +30,24 @@ class ProductServiceImpl(
         return ProductResponse.from(product)
     }
 
-    override fun updateProduct(userId: Long, productId: Long, request: ProductRequest): ProductResponse {
+    override fun registerProduct(storeId: Long, request: ProductRequest): ProductResponse {
 
-        val product = getProductIfAuthorized(userId, productId)
+        val store = storeService.getStoreIfAuthorized(SecurityUtil.getLoginUserId(), storeId)
+
+        return Product(
+            itemName = request.itemName,
+            price = request.price,
+            quantity = request.quantity,
+            description = request.description,
+            store = store
+        ).let {
+            productRepository.save(it)
+        }.let { ProductResponse.from(it) }
+    }
+
+    override fun updateProduct(storeId: Long, productId: Long, request: ProductRequest): ProductResponse {
+
+        val product = getProductIfAuthorized(storeId, productId)
 
         product.updateProduct(request)
 
@@ -54,23 +55,21 @@ class ProductServiceImpl(
             .let { ProductResponse.from(it) }
     }
 
-    override fun deleteProduct(userId: Long, productId: Long) {
+    override fun deleteProduct(storeId: Long, productId: Long) {
 
-        val product = getProductIfAuthorized(userId, productId)
+        val product = getProductIfAuthorized(storeId, productId)
 
         productRepository.deleteProductById(product.id!!)
     }
 
-    private fun getProductIfAuthorized(userId: Long, productId: Long): Product {
+    private fun getProductIfAuthorized(storeId: Long, productId: Long): Product {
 
-        if (!userRepository.existsById(userId)) {
-            throw ModelNotFoundException("User", userId)
-        }
+        val store = storeService.getStoreIfAuthorized(SecurityUtil.getLoginUserId(), storeId)
 
         val product = productRepository.findProductById(productId) ?: throw ModelNotFoundException("Product", productId)
 
-        if (!product.matchUserId(userId)) {
-            throw ForbiddenException(userId, "Product", productId)
+        if (!product.matchStoreId(store.id!!)) {
+            throw ForbiddenException(SecurityUtil.getLoginUserId()!!, "Product", productId)
         }
 
         return product

--- a/src/main/kotlin/com/naever/store/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/controller/StoreController.kt
@@ -1,22 +1,22 @@
 package com.naever.store.domain.store.controller
 
+import com.naever.store.domain.product.dto.ProductPageRequest
+import com.naever.store.domain.product.dto.ProductPageResponse
+import com.naever.store.domain.product.dto.ProductRequest
+import com.naever.store.domain.product.dto.ProductResponse
+import com.naever.store.domain.product.service.ProductService
 import com.naever.store.domain.store.dto.StoreRequest
 import com.naever.store.domain.store.dto.StoreResponse
 import com.naever.store.domain.store.service.StoreService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/stores")
 class StoreController(
-    private val storeService: StoreService
+    private val storeService: StoreService,
+    private val productService: ProductService
 ) {
 
     @PostMapping
@@ -38,6 +38,63 @@ class StoreController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(storeService.updateStore(storeId, request))
+    }
+
+    @GetMapping("/{storeId}/products")
+    fun getProductList(
+        @PathVariable storeId: Long,
+        @RequestParam(defaultValue = "1") pageNumber: Int,
+        @RequestParam(defaultValue = "5") pageSize: Int,
+        request: ProductPageRequest
+    ): ResponseEntity<ProductPageResponse> {
+
+        val request = ProductPageRequest(
+            sort = request.sort,
+            itemName = request.itemName,
+            startPrice = request.startPrice,
+            endPrice = request.endPrice,
+            storeId = storeId
+        )
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(productService.getProductList(pageNumber, pageSize, request))
+    }
+
+    @PostMapping("/{storeId}/products")
+    fun registerProduct(
+        @PathVariable storeId: Long,
+        @RequestBody request: ProductRequest
+    ): ResponseEntity<ProductResponse> {
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(productService.registerProduct(storeId, request))
+    }
+
+    @PutMapping("/{storeId}/products/{productId}")
+    fun updateProduct(
+        @PathVariable storeId: Long,
+        @PathVariable productId: Long,
+        @RequestBody request: ProductRequest
+    ): ResponseEntity<ProductResponse> {
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(productService.updateProduct(storeId, productId, request))
+    }
+
+    @DeleteMapping("/{storeId}/products/{productId}")
+    fun deleteProduct(
+        @PathVariable storeId: Long,
+        @PathVariable productId: Long
+    ): ResponseEntity<Unit> {
+
+        productService.deleteProduct(storeId, productId)
+
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build()
     }
 
 }

--- a/src/main/kotlin/com/naever/store/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/controller/StoreController.kt
@@ -5,6 +5,7 @@ import com.naever.store.domain.store.dto.StoreResponse
 import com.naever.store.domain.store.service.StoreService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -25,10 +26,17 @@ class StoreController(
             .body(storeService.createStore(request))
     }
 
+    @GetMapping("/{storeId}")
+    fun getStore(@PathVariable storeId: Long): ResponseEntity<StoreResponse> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(storeService.getStore(storeId))
+    }
+
     @PutMapping("/{storeId}")
     fun updateStore(@PathVariable storeId: Long, @RequestBody request: StoreRequest): ResponseEntity<StoreResponse> {
         return ResponseEntity
-            .status(HttpStatus.CREATED)
+            .status(HttpStatus.OK)
             .body(storeService.updateStore(storeId, request))
     }
 

--- a/src/main/kotlin/com/naever/store/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/controller/StoreController.kt
@@ -40,6 +40,14 @@ class StoreController(
             .body(storeService.updateStore(storeId, request))
     }
 
+    @DeleteMapping("/{storeId}")
+    fun deleteStore(@PathVariable storeId: Long): ResponseEntity<Unit> {
+        storeService.deleteStore(storeId)
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build()
+    }
+
     @GetMapping("/{storeId}/products")
     fun getProductList(
         @PathVariable storeId: Long,

--- a/src/main/kotlin/com/naever/store/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/controller/StoreController.kt
@@ -5,7 +5,9 @@ import com.naever.store.domain.store.dto.StoreResponse
 import com.naever.store.domain.store.service.StoreService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -22,4 +24,12 @@ class StoreController(
             .status(HttpStatus.CREATED)
             .body(storeService.createStore(request))
     }
+
+    @PutMapping("/{storeId}")
+    fun updateStore(@PathVariable storeId: Long, @RequestBody request: StoreRequest): ResponseEntity<StoreResponse> {
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(storeService.updateStore(storeId, request))
+    }
+
 }

--- a/src/main/kotlin/com/naever/store/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/controller/StoreController.kt
@@ -1,0 +1,25 @@
+package com.naever.store.domain.store.controller
+
+import com.naever.store.domain.store.dto.StoreRequest
+import com.naever.store.domain.store.dto.StoreResponse
+import com.naever.store.domain.store.service.StoreService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/stores")
+class StoreController(
+    private val storeService: StoreService
+) {
+
+    @PostMapping
+    fun createStore(@RequestBody request: StoreRequest): ResponseEntity<StoreResponse> {
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(storeService.createStore(request))
+    }
+}

--- a/src/main/kotlin/com/naever/store/domain/store/dto/StoreRequest.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/dto/StoreRequest.kt
@@ -1,0 +1,6 @@
+package com.naever.store.domain.store.dto
+
+data class StoreRequest(
+    val name: String,
+    val introduction: String
+)

--- a/src/main/kotlin/com/naever/store/domain/store/dto/StoreResponse.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/dto/StoreResponse.kt
@@ -1,0 +1,24 @@
+package com.naever.store.domain.store.dto
+
+import com.naever.store.domain.store.model.Store
+import java.time.ZonedDateTime
+
+data class StoreResponse(
+    val id: Long?,
+    val name: String,
+    val introduction: String,
+    val createdAt: ZonedDateTime,
+    val userId: Long?
+) {
+    companion object {
+        fun from(store: Store): StoreResponse {
+            return StoreResponse(
+                id = store.id,
+                name = store.name,
+                introduction = store.introduction,
+                createdAt = store.createdAt,
+                userId = store.user.id
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/naever/store/domain/store/model/Store.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/model/Store.kt
@@ -1,0 +1,26 @@
+package com.naever.store.domain.store.model
+
+import com.naever.store.common.BaseTimeEntity
+import com.naever.store.domain.user.model.User
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "store")
+class Store(
+
+    @Column(name = "name")
+    var name: String,
+
+    @Column(name = "introduction")
+    var introduction: String,
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    var user: User
+
+): BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+}

--- a/src/main/kotlin/com/naever/store/domain/store/model/Store.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/model/Store.kt
@@ -1,6 +1,7 @@
 package com.naever.store.domain.store.model
 
 import com.naever.store.common.BaseTimeEntity
+import com.naever.store.domain.store.dto.StoreRequest
 import com.naever.store.domain.user.model.User
 import jakarta.persistence.*
 
@@ -23,4 +24,14 @@ class Store(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
+
+    fun matchUserId(requestUserId: Long): Boolean {
+        return user.id == requestUserId
+    }
+
+    fun update(request: StoreRequest) {
+        name = request.name
+        introduction = request.introduction
+    }
+
 }

--- a/src/main/kotlin/com/naever/store/domain/store/model/Store.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/model/Store.kt
@@ -4,9 +4,11 @@ import com.naever.store.common.BaseTimeEntity
 import com.naever.store.domain.store.dto.StoreRequest
 import com.naever.store.domain.user.model.User
 import jakarta.persistence.*
+import org.hibernate.annotations.SQLRestriction
 
 @Entity
 @Table(name = "store")
+@SQLRestriction("is_deleted <> true")
 class Store(
 
     @Column(name = "name")
@@ -15,7 +17,7 @@ class Store(
     @Column(name = "introduction")
     var introduction: String,
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     var user: User
 
@@ -32,6 +34,10 @@ class Store(
     fun update(request: StoreRequest) {
         name = request.name
         introduction = request.introduction
+    }
+
+    fun delete() {
+        isDeleted = true
     }
 
 }

--- a/src/main/kotlin/com/naever/store/domain/store/repository/IStoreRepository.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/IStoreRepository.kt
@@ -8,4 +8,6 @@ interface IStoreRepository {
 
     fun findById(id: Long): Store?
 
+    fun existsByUserId(userId: Long): Boolean
+
 }

--- a/src/main/kotlin/com/naever/store/domain/store/repository/IStoreRepository.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/IStoreRepository.kt
@@ -1,0 +1,8 @@
+package com.naever.store.domain.store.repository
+
+import com.naever.store.domain.store.model.Store
+
+interface IStoreRepository {
+
+    fun save(store: Store): Store
+}

--- a/src/main/kotlin/com/naever/store/domain/store/repository/IStoreRepository.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/IStoreRepository.kt
@@ -8,4 +8,6 @@ interface IStoreRepository {
 
     fun findById(id: Long): Store?
 
+    fun findByUserId(userId: Long): Store?
+
 }

--- a/src/main/kotlin/com/naever/store/domain/store/repository/IStoreRepository.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/IStoreRepository.kt
@@ -5,4 +5,7 @@ import com.naever.store.domain.store.model.Store
 interface IStoreRepository {
 
     fun save(store: Store): Store
+
+    fun findById(id: Long): Store?
+
 }

--- a/src/main/kotlin/com/naever/store/domain/store/repository/IStoreRepository.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/IStoreRepository.kt
@@ -8,6 +8,4 @@ interface IStoreRepository {
 
     fun findById(id: Long): Store?
 
-    fun findByUserId(userId: Long): Store?
-
 }

--- a/src/main/kotlin/com/naever/store/domain/store/repository/StoreJpaRepository.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/StoreJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.naever.store.domain.store.repository
+
+import com.naever.store.domain.store.model.Store
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface StoreJpaRepository : JpaRepository<Store, Long> {
+}

--- a/src/main/kotlin/com/naever/store/domain/store/repository/StoreJpaRepository.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/StoreJpaRepository.kt
@@ -4,4 +4,7 @@ import com.naever.store.domain.store.model.Store
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface StoreJpaRepository : JpaRepository<Store, Long> {
+
+    fun existsByUserId(userId: Long): Boolean
+
 }

--- a/src/main/kotlin/com/naever/store/domain/store/repository/StoreRepositoryImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/StoreRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.naever.store.domain.store.repository
+
+import com.naever.store.domain.store.model.Store
+import com.naever.store.infra.querydsl.QueryDslSupport
+
+class StoreRepositoryImpl(
+    private val storeJpaRepository: StoreJpaRepository
+) : IStoreRepository, QueryDslSupport() {
+
+    override fun save(store: Store): Store {
+        return storeJpaRepository.save(store)
+    }
+
+}

--- a/src/main/kotlin/com/naever/store/domain/store/repository/StoreRepositoryImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/StoreRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.naever.store.domain.store.repository
 
 import com.naever.store.domain.store.model.Store
 import com.naever.store.infra.querydsl.QueryDslSupport
+import org.springframework.data.repository.findByIdOrNull
 
 class StoreRepositoryImpl(
     private val storeJpaRepository: StoreJpaRepository
@@ -9,6 +10,10 @@ class StoreRepositoryImpl(
 
     override fun save(store: Store): Store {
         return storeJpaRepository.save(store)
+    }
+
+    override fun findById(id: Long): Store? {
+        return storeJpaRepository.findByIdOrNull(id)
     }
 
 }

--- a/src/main/kotlin/com/naever/store/domain/store/repository/StoreRepositoryImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/StoreRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.naever.store.domain.store.repository
 
+import com.naever.store.domain.store.model.QStore
 import com.naever.store.domain.store.model.Store
 import com.naever.store.infra.querydsl.QueryDslSupport
 import org.springframework.data.repository.findByIdOrNull
@@ -8,12 +9,20 @@ class StoreRepositoryImpl(
     private val storeJpaRepository: StoreJpaRepository
 ) : IStoreRepository, QueryDslSupport() {
 
+    val store = QStore.store
+
     override fun save(store: Store): Store {
         return storeJpaRepository.save(store)
     }
 
     override fun findById(id: Long): Store? {
         return storeJpaRepository.findByIdOrNull(id)
+    }
+
+    override fun findByUserId(userId: Long): Store? {
+        return queryFactory.select(store)
+            .where(store.user.id.eq(userId))
+            .fetchOne()
     }
 
 }

--- a/src/main/kotlin/com/naever/store/domain/store/repository/StoreRepositoryImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/repository/StoreRepositoryImpl.kt
@@ -7,9 +7,7 @@ import org.springframework.data.repository.findByIdOrNull
 
 class StoreRepositoryImpl(
     private val storeJpaRepository: StoreJpaRepository
-) : IStoreRepository, QueryDslSupport() {
-
-    val store = QStore.store
+) : IStoreRepository {
 
     override fun save(store: Store): Store {
         return storeJpaRepository.save(store)
@@ -17,12 +15,6 @@ class StoreRepositoryImpl(
 
     override fun findById(id: Long): Store? {
         return storeJpaRepository.findByIdOrNull(id)
-    }
-
-    override fun findByUserId(userId: Long): Store? {
-        return queryFactory.select(store)
-            .where(store.user.id.eq(userId))
-            .fetchOne()
     }
 
 }

--- a/src/main/kotlin/com/naever/store/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/service/StoreService.kt
@@ -1,0 +1,9 @@
+package com.naever.store.domain.store.service
+
+import com.naever.store.domain.store.dto.StoreRequest
+import com.naever.store.domain.store.dto.StoreResponse
+
+interface StoreService {
+
+    fun createStore(request: StoreRequest): StoreResponse
+}

--- a/src/main/kotlin/com/naever/store/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/service/StoreService.kt
@@ -6,4 +6,7 @@ import com.naever.store.domain.store.dto.StoreResponse
 interface StoreService {
 
     fun createStore(request: StoreRequest): StoreResponse
+
+    fun updateStore(storeId: Long, request: StoreRequest): StoreResponse
+
 }

--- a/src/main/kotlin/com/naever/store/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/service/StoreService.kt
@@ -12,6 +12,8 @@ interface StoreService {
 
     fun updateStore(storeId: Long, request: StoreRequest): StoreResponse
 
+    fun deleteStore(storeId: Long)
+
     fun getStoreIfAuthorized(userId: Long?, storeId: Long): Store
 
 }

--- a/src/main/kotlin/com/naever/store/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/service/StoreService.kt
@@ -2,6 +2,7 @@ package com.naever.store.domain.store.service
 
 import com.naever.store.domain.store.dto.StoreRequest
 import com.naever.store.domain.store.dto.StoreResponse
+import com.naever.store.domain.store.model.Store
 
 interface StoreService {
 
@@ -10,5 +11,7 @@ interface StoreService {
     fun getStore(storeId: Long): StoreResponse
 
     fun updateStore(storeId: Long, request: StoreRequest): StoreResponse
+
+    fun getStoreIfAuthorized(userId: Long?, storeId: Long): Store
 
 }

--- a/src/main/kotlin/com/naever/store/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/service/StoreService.kt
@@ -7,6 +7,8 @@ interface StoreService {
 
     fun createStore(request: StoreRequest): StoreResponse
 
+    fun getStore(storeId: Long): StoreResponse
+
     fun updateStore(storeId: Long, request: StoreRequest): StoreResponse
 
 }

--- a/src/main/kotlin/com/naever/store/domain/store/service/StoreServiceImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/service/StoreServiceImpl.kt
@@ -1,0 +1,35 @@
+package com.naever.store.domain.store.service
+
+import com.naever.store.domain.exception.ModelNotFoundException
+import com.naever.store.domain.store.dto.StoreRequest
+import com.naever.store.domain.store.dto.StoreResponse
+import com.naever.store.domain.store.model.Store
+import com.naever.store.domain.store.repository.IStoreRepository
+import com.naever.store.domain.user.repository.UserRepository
+import com.naever.store.infra.security.SecurityUtil
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class StoreServiceImpl(
+    private val userRepository: UserRepository,
+    private val storeRepository: IStoreRepository
+) : StoreService {
+
+    override fun createStore(request: StoreRequest): StoreResponse {
+
+        val user = userRepository.findByIdOrNull(SecurityUtil.getLoginUserId())
+            ?: throw ModelNotFoundException("User", SecurityUtil.getLoginUserId())
+
+        return Store(
+            name = request.name,
+            introduction = request.introduction,
+            user = user
+        ).let {
+            storeRepository.save(it)
+        }.let {
+            StoreResponse.from(it)
+        }
+    }
+
+}

--- a/src/main/kotlin/com/naever/store/domain/store/service/StoreServiceImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/service/StoreServiceImpl.kt
@@ -25,6 +25,10 @@ class StoreServiceImpl(
         val user = userRepository.findByIdOrNull(SecurityUtil.getLoginUserId())
             ?: throw ModelNotFoundException("User", SecurityUtil.getLoginUserId())
 
+        if (storeRepository.existsByUserId(user.id!!)) {
+            throw IllegalStateException("already created a store")
+        }
+
         return Store(
             name = request.name,
             introduction = request.introduction,

--- a/src/main/kotlin/com/naever/store/domain/store/service/StoreServiceImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/service/StoreServiceImpl.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service
 @Service
 class StoreServiceImpl(
     private val userRepository: UserRepository,
-    private val storeRepository: IStoreRepository
+    private val storeRepository: IStoreRepository,
 ) : StoreService {
 
     override fun createStore(request: StoreRequest): StoreResponse {
@@ -33,6 +33,13 @@ class StoreServiceImpl(
         }
     }
 
+    override fun getStore(storeId: Long): StoreResponse {
+
+        val store = storeRepository.findById(storeId) ?: throw ModelNotFoundException("Store", storeId)
+
+        return StoreResponse.from(store)
+    }
+
     override fun updateStore(storeId: Long, request: StoreRequest): StoreResponse {
 
         val store = getStoreIfAuthorized(SecurityUtil.getLoginUserId(), storeId)
@@ -45,8 +52,7 @@ class StoreServiceImpl(
 
     private fun getStoreIfAuthorized(userId: Long?, storeId: Long): Store {
 
-        userRepository.findByIdOrNull(userId)
-            ?: throw ModelNotFoundException("User", userId)
+        userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User", userId)
 
         val store = storeRepository.findById(storeId) ?: throw ModelNotFoundException("Store", storeId)
 

--- a/src/main/kotlin/com/naever/store/domain/store/service/StoreServiceImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/service/StoreServiceImpl.kt
@@ -50,7 +50,7 @@ class StoreServiceImpl(
             .let { StoreResponse.from(it) }
     }
 
-    private fun getStoreIfAuthorized(userId: Long?, storeId: Long): Store {
+    override fun getStoreIfAuthorized(userId: Long?, storeId: Long): Store {
 
         userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User", userId)
 

--- a/src/main/kotlin/com/naever/store/domain/store/service/StoreServiceImpl.kt
+++ b/src/main/kotlin/com/naever/store/domain/store/service/StoreServiceImpl.kt
@@ -2,6 +2,7 @@ package com.naever.store.domain.store.service
 
 import com.naever.store.domain.exception.ForbiddenException
 import com.naever.store.domain.exception.ModelNotFoundException
+import com.naever.store.domain.product.repository.IProductRepository
 import com.naever.store.domain.store.dto.StoreRequest
 import com.naever.store.domain.store.dto.StoreResponse
 import com.naever.store.domain.store.model.Store
@@ -10,11 +11,13 @@ import com.naever.store.domain.user.repository.UserRepository
 import com.naever.store.infra.security.SecurityUtil
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class StoreServiceImpl(
     private val userRepository: UserRepository,
     private val storeRepository: IStoreRepository,
+    private val productRepository: IProductRepository
 ) : StoreService {
 
     override fun createStore(request: StoreRequest): StoreResponse {
@@ -48,6 +51,17 @@ class StoreServiceImpl(
 
         return storeRepository.save(store)
             .let { StoreResponse.from(it) }
+    }
+
+    @Transactional
+    override fun deleteStore(storeId: Long) {
+
+        val store = getStoreIfAuthorized(SecurityUtil.getLoginUserId(), storeId)
+
+        productRepository.deleteAllByStoreId(storeId)
+
+        store.delete()
+        storeRepository.save(store)
     }
 
     override fun getStoreIfAuthorized(userId: Long?, storeId: Long): Store {

--- a/src/main/kotlin/com/naever/store/domain/user/dto/UserRegisterRequest.kt
+++ b/src/main/kotlin/com/naever/store/domain/user/dto/UserRegisterRequest.kt
@@ -10,11 +10,11 @@ import org.springframework.security.crypto.password.PasswordEncoder
 
 data class UserRegisterRequest(
     @field:NotBlank(message = "이메일은 필수입니다.")
-//    @field:Email(message = "이메일 형식이 아닙니다.")
+    @field:Email(message = "이메일 형식이 아닙니다.")
     val email: String,
     val address: String,
-//    @field:Length(min = 8, max = 15, message = "비밀번호는 8자 이상, 15자 이하여야합니다.")
-//    @field:Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$)", message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 사용하세요.")
+    @field:Length(min = 8, max = 15, message = "비밀번호는 8자 이상, 15자 이하여야합니다.")
+    @field:Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$)", message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 사용하세요.")
     val password: String,
     val passwordConfirm: String,
     @field:NotBlank(message = "닉네임은 필수입니다.")

--- a/src/main/kotlin/com/naever/store/domain/user/dto/UserRegisterRequest.kt
+++ b/src/main/kotlin/com/naever/store/domain/user/dto/UserRegisterRequest.kt
@@ -10,11 +10,11 @@ import org.springframework.security.crypto.password.PasswordEncoder
 
 data class UserRegisterRequest(
     @field:NotBlank(message = "이메일은 필수입니다.")
-    @field:Email(message = "이메일 형식이 아닙니다.")
+//    @field:Email(message = "이메일 형식이 아닙니다.")
     val email: String,
     val address: String,
-    @field:Length(min = 8, max = 15, message = "비밀번호는 8자 이상, 15자 이하여야합니다.")
-    @field:Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$)", message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 사용하세요.")
+//    @field:Length(min = 8, max = 15, message = "비밀번호는 8자 이상, 15자 이하여야합니다.")
+//    @field:Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$)", message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 사용하세요.")
     val password: String,
     val passwordConfirm: String,
     @field:NotBlank(message = "닉네임은 필수입니다.")


### PR DESCRIPTION
## 연관된 이슈

close #20 
상점 관련 기능

## 작업 내용

- 상점 등록
  - 사용자당 하나만 등록하도록 제한
- 상점 수정
  - 등록한 사용자만 가능
- 상점 삭제 (soft-delete)
  - 등록한 사용자만 가능
  - 상품도 함께 삭제
- 상점 조회
- Store Entity에서 is_deleted 컬럼이 true 가 아닌 경우만 조회하도록 제한
- 상점과 상품 연관관계
  - 상품 등록/수정/삭제 api StoreController 로 이동
  - 상품 response DTO에 상점이름 추가
  - 상점의 상품 조회 (page request DTO에 store id 추가)
- 상품 인가
  - 상점이 있는 경우만 등록 가능
  - 상품을 등록한 사용자만 수정/삭제 가능